### PR TITLE
Fix in case of the 'SourceLine' not be right under 'BugInstance'.

### DIFF
--- a/lib/findbugs_translate_checkstyle_format/translate.rb
+++ b/lib/findbugs_translate_checkstyle_format/translate.rb
@@ -22,7 +22,11 @@ module FindbugsTranslateCheckstyleFormat
 
       bug_instances = [bug_instances] if bug_instances.is_a?(Hash)
       bug_instances.each do |bug_instance|
-        source_lines = bug_instance['SourceLine']
+        source_lines = if bug_instance.has_key?('SourceLine')
+          bug_instance['SourceLine']
+        else
+          bug_instance['Class'].map{|classes| classes['SourceLine']}
+        end
         source_lines = [source_lines] if source_lines.is_a?(Hash)
         source_lines.each do |source_line|
           file = checkstyle.add_element('file',

--- a/lib/findbugs_translate_checkstyle_format/translate.rb
+++ b/lib/findbugs_translate_checkstyle_format/translate.rb
@@ -22,13 +22,14 @@ module FindbugsTranslateCheckstyleFormat
 
       bug_instances = [bug_instances] if bug_instances.is_a?(Hash)
       bug_instances.each do |bug_instance|
-        source_lines = if bug_instance.has_key?('SourceLine')
-          bug_instance['SourceLine']
-        elsif bug_instance['Class'].is_a?(Array)
-          bug_instance['Class'].map{|classes| classes['SourceLine']}
-        else
-          bug_instance['Class']['SourceLine']
-        end
+        source_lines =
+          if bug_instance.key?('SourceLine')
+            bug_instance['SourceLine']
+          elsif bug_instance['Class'].is_a?(Array)
+            bug_instance['Class'].map { |classes| classes['SourceLine'] }
+          else
+            bug_instance['Class']['SourceLine']
+          end
         source_lines = [source_lines] if source_lines.is_a?(Hash)
         source_lines.each do |source_line|
           file = checkstyle.add_element('file',

--- a/lib/findbugs_translate_checkstyle_format/translate.rb
+++ b/lib/findbugs_translate_checkstyle_format/translate.rb
@@ -24,8 +24,10 @@ module FindbugsTranslateCheckstyleFormat
       bug_instances.each do |bug_instance|
         source_lines = if bug_instance.has_key?('SourceLine')
           bug_instance['SourceLine']
-        else
+        elsif bug_instance['Class'].is_a?(Array)
           bug_instance['Class'].map{|classes| classes['SourceLine']}
+        else
+          bug_instance['Class']['SourceLine']
         end
         source_lines = [source_lines] if source_lines.is_a?(Hash)
         source_lines.each do |source_line|

--- a/spec/findbugs_translate_checkstyle_format/translate_spec.rb
+++ b/spec/findbugs_translate_checkstyle_format/translate_spec.rb
@@ -129,6 +129,27 @@ describe FindbugsTranslateCheckstyleFormat::Translate do
         expect(doc.get_elements('/checkstyle/file').first.attribute('name').value).to eq('test.java')
       end
     end
+    context 'single BugInstance and SourceLine in single Class' do
+      xml = {
+        'BugCollection' => {
+          'BugInstance' => {
+            'Class' => {
+              'SourceLine' => {
+                '@classname' => 'com.example.Test',
+                '@start' => 12
+              }
+            }
+          }
+        }
+      }
+      subject(:doc) { trans(xml) }
+      it 'return blank dom' do
+        expect(doc.get_elements('/checkstyle/file/error')).not_to be_empty
+        expect(doc.get_elements('/checkstyle/file/error')[0].attribute('line').value).to eq('12')
+        expect(doc.get_elements('/checkstyle/file/error')[0].attribute('message').value).not_to be_nil
+        expect(doc.get_elements('/checkstyle/file').first.attribute('name').value).to eq('test.java')
+      end
+    end
   end
 
   describe 'fqcn_to_path' do

--- a/spec/findbugs_translate_checkstyle_format/translate_spec.rb
+++ b/spec/findbugs_translate_checkstyle_format/translate_spec.rb
@@ -98,6 +98,37 @@ describe FindbugsTranslateCheckstyleFormat::Translate do
         expect(doc.get_elements('/checkstyle/file').first.attribute('name').value).to eq('test.java')
       end
     end
+    context 'single BugInstance and SourceLine in many Class' do
+      xml = {
+        'BugCollection' => {
+          'BugInstance' => {
+            'Class' => [
+              {
+                'SourceLine' => {
+                  '@classname' => 'com.example.Test',
+                  '@start' => 12
+                }
+              },
+              {
+                'SourceLine' => {
+                  '@classname' => 'com.example.Test',
+                  '@start' => 14
+                }
+              }
+            ]
+          }
+        }
+      }
+      subject(:doc) { trans(xml) }
+      it 'return blank dom' do
+        expect(doc.get_elements('/checkstyle/file').count).to eq(2)
+        expect(doc.get_elements('/checkstyle/file[1]/error').first.attribute('line').value).to eq('12')
+        expect(doc.get_elements('/checkstyle/file[1]/error').first.attribute('message').value).not_to be_nil
+        expect(doc.get_elements('/checkstyle/file[2]/error').first.attribute('line').value).to eq('14')
+        expect(doc.get_elements('/checkstyle/file[2]/error').first.attribute('message').value).not_to be_nil
+        expect(doc.get_elements('/checkstyle/file').first.attribute('name').value).to eq('test.java')
+      end
+    end
   end
 
   describe 'fqcn_to_path' do


### PR DESCRIPTION
## single BugInstance and SourceLine in single Class
e.g. 
```java
public class Clazz {

    private int i;
}
```
From the source code above, Findbugs generate XML file below:
```xml
  <BugInstance type="UUF_UNUSED_FIELD" priority="2" rank="18" abbrev="UuF" category="PERFORMANCE">
    <Class classname="Clazz">
      <SourceLine classname="Clazz" start="1" end="1" sourcefile="Clazz.java" sourcepath="Clazz.java"/>
    </Class>
    <Field classname="Clazz" name="i" signature="I" isStatic="false">
      <SourceLine classname="Clazz" sourcefile="Clazz.java" sourcepath="Clazz.java"/>
    </Field>
  </BugInstance>
```

## single BugInstance and SourceLine in many Class
e.g.
```java
package com.example.parent;

public class Clazz {

}
```
```java
package com.example.child;

public class Clazz extends com.example.parent.Clazz {

}

```
From the source code above, Findbugs generate XML file below:
```xml
  <BugInstance type="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" priority="1" rank="14" abbrev="Nm" category="BAD_PRACTICE">
    <Class classname="com.example.child.Clazz">
      <SourceLine classname="com.example.child.Clazz" start="3" end="3" sourcefile="Clazz.java" sourcepath="com/example/child/Clazz.java"/>
    </Class>
    <Class classname="com.example.parent.Clazz">
      <SourceLine classname="com.example.parent.Clazz" start="3" end="3" sourcefile="Clazz.java" sourcepath="com/example/parent/Clazz.java"/>
    </Class>
  </BugInstance>
```